### PR TITLE
integrating Whiteboard using viewmodel approach

### DIFF
--- a/src/MessengerApp/Views/ClientMeetingView.xaml
+++ b/src/MessengerApp/Views/ClientMeetingView.xaml
@@ -6,6 +6,7 @@
              xmlns:local="clr-namespace:MessengerApp.Views"
              xmlns:viewmodels="clr-namespace:MessengerDashboard.UI.ViewModels;assembly=MessengerDashboard"
              xmlns:screenshare="clr-namespace:MessengerScreenshare.Client;assembly=MessengerScreenshare"
+             xmlns:whiteboard="clr-namespace:MessengerWhiteboard;assembly=MessengerWhiteboard"
              xmlns:views="clr-namespace:MessengerApp.Views"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
@@ -15,15 +16,18 @@
             <DataTemplate DataType="{x:Type viewmodels:DashboardMemberViewModel}">
                 <views:DashboardMemberControl/>
             </DataTemplate>
+            <DataTemplate DataType="{x:Type whiteboard:ViewModel}">
+                <views:WhiteboardControl/>
+            </DataTemplate>
             <DataTemplate DataType="{x:Type screenshare:ScreenshareClientViewModel}">
                 <views:ScreenshareClientControl/>
             </DataTemplate>
         </Grid.Resources>
         <Menu>
             <MenuItem Header="Dashboard" Command="{Binding NavigateClientDashboardCommand}"/>
-            <MenuItem Header="Whiteboard"/>
+            <MenuItem Header="Whiteboard" Command="{Binding NavigateServerWhiteboardCommand}"/>
             <MenuItem Header="Screenshare" Command="{Binding NavigateClientScreenshareCommand}"/>
-            <MenuItem Header="Participants"/>
+            <!--MenuItem Header="Participants"/-->
             <MenuItem Header="Chat" Click="Chat_Click"/>
             <!--<TextBlock Text="{Binding IP}"></TextBlock>
             <TextBlock Text="{Binding Port}"></TextBlock>-->

--- a/src/MessengerApp/Views/HostMeetingView.xaml
+++ b/src/MessengerApp/Views/HostMeetingView.xaml
@@ -17,9 +17,9 @@
             <DataTemplate DataType="{x:Type viewmodels:DashboardInstructorViewModel}">
                 <views:DashboardControl/>
             </DataTemplate>
-            <!--<DataTemplate DataType="{x:Type whiteboard:ViewModel}">
+            <DataTemplate DataType="{x:Type whiteboard:ViewModel}">
                 <views:WhiteboardControl/>
-            </DataTemplate>-->
+            </DataTemplate>
             <DataTemplate DataType="{x:Type screenshare:ScreenshareServerViewModel}">
                 <views:ScreenshareServerControl/>
             </DataTemplate>

--- a/src/MessengerApp/Views/WhiteboardControl.xaml.cs
+++ b/src/MessengerApp/Views/WhiteboardControl.xaml.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -22,17 +22,16 @@ namespace MessengerApp.Views
     /// </summary>
     public partial class WhiteboardControl : UserControl
     {
-        readonly ViewModel _viewModel;
+        ViewModel _viewModel => ViewModel.Instance;
         private bool _buildingShape = false;
 
-        public WhiteboardControl(int serverID)
+        public WhiteboardControl()
         {
             InitializeComponent();
 
-            _viewModel = ViewModel.Instance;
+            DataContext = ViewModel.Instance;
             _viewModel.ShapeItems = new();
-            DataContext = _viewModel;
-            _viewModel.SetUserID(serverID);
+
         }
 
         //private void SampleRectangleClick(object sender, RoutedEventArgs e)

--- a/src/MessengerViewModels/ViewModels/ClientMeetViewModel.cs
+++ b/src/MessengerViewModels/ViewModels/ClientMeetViewModel.cs
@@ -11,6 +11,7 @@ using MessengerDashboard.Client;
 using MessengerDashboard;
 using MessengerDashboard.UI.ViewModels;
 using MessengerScreenshare.Client;
+using MessengerWhiteboard;
 
 namespace MessengerViewModels.ViewModels
 {
@@ -21,12 +22,13 @@ namespace MessengerViewModels.ViewModels
 
         public ICommand NavigateClientScreenshareCommand { get; }
 
+        public ICommand NavigateServerWhiteboardCommand { get; }
 
         public object SubViewModel => _navigationStore.SubViewModel;
 
         private readonly DashboardMemberViewModel _dashboardViewModel;
         private readonly ScreenshareClientViewModel _screenshareViewModel;
-
+        private readonly MessengerWhiteboard.ViewModel _whiteboardViewModel;
 
 
         private readonly IClientSessionController _client = DashboardFactory.GetClientSessionController();
@@ -39,12 +41,18 @@ namespace MessengerViewModels.ViewModels
         {
             _dashboardViewModel = new DashboardMemberViewModel();
             _screenshareViewModel = new ScreenshareClientViewModel();
+            _whiteboardViewModel = new MessengerWhiteboard.ViewModel();
+
+
+            _whiteboardViewModel = MessengerWhiteboard.ViewModel.Instance;
+            _whiteboardViewModel.SetUserID(1);
 
             _navigationStore = navigationStore;
             navigationStore.SubViewModelChanged += NavigationStore_SubViewModelChanged;
             NavigateHomeCommand = new NavigateHomeCommand(navigationStore);
             NavigateClientDashboardCommand = new NavigateClientDashboardCommand(navigationStore, _dashboardViewModel);
             NavigateClientScreenshareCommand = new NavigateClientScreenshareCommand(navigationStore, _screenshareViewModel);
+            NavigateServerWhiteboardCommand = new NavigateServerWhiteboardCommand(navigationStore, _whiteboardViewModel);
 
         }
 

--- a/src/MessengerViewModels/ViewModels/ServerMeetViewModel.cs
+++ b/src/MessengerViewModels/ViewModels/ServerMeetViewModel.cs
@@ -28,6 +28,8 @@ namespace MessengerViewModels.ViewModels
 
         private readonly DashboardInstructorViewModel _dashboardViewModel;
         private readonly MessengerWhiteboard.ViewModel _whiteboardViewModel;
+        
+
         private readonly MessengerScreenshare.Server.ScreenshareServerViewModel _screenshareServerViewModel;
 
         public int Port { get; set; }
@@ -48,6 +50,10 @@ namespace MessengerViewModels.ViewModels
             navigationStore.SubViewModelChanged += NavigationStore_SubViewModelChanged;
             Port = _server.ConnectionDetails.Port;
             IP = _server.ConnectionDetails.IpAddress;
+
+            _whiteboardViewModel = MessengerWhiteboard.ViewModel.Instance;
+            _whiteboardViewModel.SetUserID(0);
+
             NavigateServerDashboardCommand = new NavigateServerDashboardCommand(navigationStore, _dashboardViewModel);
             NavigateServerWhiteboardCommand = new NavigateServerWhiteboardCommand(navigationStore, _whiteboardViewModel);
             NavigateServerScreenshareCommand = new NavigateServerScreenshareCommand(navigationStore, _screenshareServerViewModel);


### PR DESCRIPTION
Added navigation command for whiteboard in client and host meeting views.
Whiteboard control now does not have a parameter, we do setuserID as 0 or 1 in ServerMeetViewModel and ClientMeetViewModel respectively.
Closes whiteboard integration Issue  &dArr;
- #134 